### PR TITLE
Remove extra "taxonomies" div

### DIFF
--- a/templates/index.liquid
+++ b/templates/index.liquid
@@ -1,5 +1,4 @@
 <div id="sidebar" class="clearfix">
-  <div id="taxonomies" class="sidebar-item">
 
   <div id="taxonomies" class="sidebar-item">
     {% unless categories.size == 0 %}


### PR DESCRIPTION
Hey @etagwerker, @lubc, 

This PR fixes what looks like a merge conflict. We have a duplicate div in the sidebar, with id `taxonomies`, which causes the theme to hide the products from the index. 

I fixed it manually for seller `paper-distribuidoras`, but any new sellers will have the same problem until we merge this. 

Please check it out, thanks! 